### PR TITLE
localOrigin instead of localPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Express middleware enabling Azure Easy Auth locally during development and testing.
 
-Version 1.0.6
+Version 1.0.7
 
 # Overview
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ const authLocal = require('azure-easy-auth-local');
 
 // The following two constants could be in your configuration file.
 const azureHost = 'myapp.azurewebsites.net';
-const localPort = 'https://localhost:45608';
+const localOrigin = 'https://localhost:45608';
 
 // This is only an example. Your app would have additional endpoints.
 const app = express();
 
-app.use(authLocal(azureHost, localPort));
+app.use(authLocal(azureHost, localOrigin));
 
 // Listen on either a pipe (once deployed) or a port (localhost).
 app.listen(process.env.PORT || 45608);

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const authLocal = require('azure-easy-auth-local');
 
 // The following two constants could be in your configuration file.
 const azureHost = 'myapp.azurewebsites.net';
-const localPort = 45608;
+const localPort = 'https://localhost:45608';
 
 // This is only an example. Your app would have additional endpoints.
 const app = express();
@@ -28,7 +28,7 @@ const app = express();
 app.use(authLocal(azureHost, localPort));
 
 // Listen on either a pipe (once deployed) or a port (localhost).
-app.listen(process.env.PORT || localPort);
+app.listen(process.env.PORT || 45608);
 ```
 
 # Web Application

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-easy-auth-local",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Express middleware enabling Azure Easy Auth locally during development and testing.",
   "main": "azure-easy-auth-local.js",
   "scripts": {


### PR DESCRIPTION
This provides the flexibility to have local development server run on `https` or `http`